### PR TITLE
Add a PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+# Overview
+
+# Checklist
+
+[ ] If I changed code, I ran `yarn build` and committed resulting changes.
+[ ] I added an example exercising this PRs functionality to `.github/workflows/test.yml` or explained why it doesn't make sense to do so.


### PR DESCRIPTION
When I last made changes to this project I forgot to run `yarn build`, not realizing that I had to do it manually. This PR request template guides future programmers to make sure they do that.