### PR TITLE
Clarify action as a starting point

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Find license compliance and security issues in your applications with [FOSSA](ht
 * Secure your open source code with accurate vulnerability detection and continuous integration
 
 ## About FOSSA Action
+
+> [!NOTE]
+> This GitHub action is primarily intended to be a quick and easy starting point.<br>
+> For more customization, we recommend [integrating FOSSA CLI directly](https://github.com/fossas/fossa-cli?tab=readme-ov-file#getting-started) in your CI pipeline.
+>
+> You can reference our public repositories for examples on how to do this if desired:
+> - [FOSSA CLI](https://github.com/fossas/fossa-cli/blob/master/.github/workflows/dependency-scan.yml)
+> - [FOSSA Broker](https://github.com/fossas/broker/blob/main/.github/workflows/dependency-scan.yml)
+
 FOSSA Action provides an easy to use entry point to using FOSSA in your github workflow. This github action will run FOSSA CLI in your github workflows with, at minimum, an API key. Below you can find [input documentation](#inputs) and [examples](#examples).
 
 FOSSA Action will run on any linux runner or on a MacOS runner. **Note**: In order to use container scanning, a running docker daemon is required - unfortunately Github's MacOS runner does not provide docker.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Find license compliance and security issues in your applications with [FOSSA](ht
 
 > [!NOTE]
 > This GitHub action is primarily intended to be a quick and easy starting point.<br>
-> For more customization, we recommend [integrating FOSSA CLI directly](https://github.com/fossas/fossa-cli?tab=readme-ov-file#getting-started) in your CI pipeline.
+> For more customization or expanded platform support (e.g. Windows), we recommend [integrating FOSSA CLI directly](https://github.com/fossas/fossa-cli?tab=readme-ov-file#getting-started) in your CI pipeline.
 >
 > You can reference our public repositories for examples on how to do this if desired:
 > - [FOSSA CLI](https://github.com/fossas/fossa-cli/blob/master/.github/workflows/dependency-scan.yml)
@@ -23,7 +23,7 @@ FOSSA Action provides an easy to use entry point to using FOSSA in your github w
 
 FOSSA Action will run on any linux runner or on a MacOS runner. **Note**: In order to use container scanning, a running docker daemon is required - unfortunately Github's MacOS runner does not provide docker.
 
-Windows is not currently supported.
+Windows is not currently supported in this action, although it is supported when integrating FOSSA CLI directly.
 
 ### Versioning
 Please note: Versioning of this action does not correspond to the version of FOSSA CLI. This Action will always use the latest version of FOSSA CLI found [here](https://github.com/fossas/fossa-cli/releases).


### PR DESCRIPTION
# Overview

Updates the readme to explicitly point out that the action is intended to be a starting point, and that for more customization users should prefer to integrate FOSSA CLI directly.

[Rendered preview](https://github.com/fossas/fossa-action/tree/note-starting-point?tab=readme-ov-file#about-fossa-action)

# Checklist

[x] If I changed code, I ran `yarn build` and committed resulting changes.
[x] I added an example exercising this PRs functionality to `.github/workflows/test.yml` or explained why it doesn't make sense to do so.
