### PR TITLE
Make dependabot ignore major version upgrades to @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
# Overview

Adds a dependabot ignore rule to skip major version bumps for `@types/node`. This avoids dependabot PRs like https://github.com/fossas/fossa-action/pull/289 that propose upgrading `@types/node` to the 25.X.X branch. This would create a type/runtime mismatch with our Node 24 LTS target. Patch/minor updates within v24.x will still be proposed.

# Checklist

- [x] If I changed code, I ran `yarn build` and committed resulting changes.
  - No code changes, only dependabot config.
- [x] I added an example exercising this PRs functionality to `.github/workflows/test.yml` or explained why it doesn't make sense to do so.
  - This is a dependabot config change, not testable in CI.

> [!IMPORTANT]
>
> After merging, make sure to create a new GitHub release and associated tag for this release.
> You can either create the tag locally and then create a corresponding GitHub release,
> or just create both the tag and release using the GitHub Release UI.
>
> Additionally, if this is not a breaking change, make sure to update the `v1` tag:
>
> ```shell
> # Check out the tag you want to set as `v1`.
> git checkout $TAG
>
> # Delete and re-create the `v1` tag.
> git tag -d v1 && git push origin :refs/tags/v1 && git tag v1 && git push origin tag v1
> ```